### PR TITLE
serverinfo command handle error for guild without icon

### DIFF
--- a/cogs/normal/general-normal.py
+++ b/cogs/normal/general-normal.py
@@ -79,9 +79,10 @@ class General(commands.Cog, name="general-normal"):
             description=f"{context.guild}",
             color=0x9C84EF
         )
-        embed.set_thumbnail(
-            url=context.guild.icon.url
-        )
+        if context.guild.icon is not None:
+            embed.set_thumbnail(
+                url=context.guild.icon.url
+            )
         embed.add_field(
             name="Server ID",
             value=context.guild.id

--- a/cogs/slash/general-slash.py
+++ b/cogs/slash/general-slash.py
@@ -79,9 +79,10 @@ class General(commands.Cog, name="general-slash"):
             description=f"{interaction.guild}",
             color=0x9C84EF
         )
-        embed.set_thumbnail(
-            url=interaction.guild.icon.url
-        )
+        if interaction.guild.icon is not None:            
+            embed.set_thumbnail(
+                url=interaction.guild.icon.url
+            )
         embed.add_field(
             name="Server ID",
             value=interaction.guild.id


### PR DESCRIPTION
Bot errors when there is no server icon present.