### PR TITLE
Add new owner only commands - (un)sync & (re)(un)load

### DIFF
--- a/UPDATES.md
+++ b/UPDATES.md
@@ -2,6 +2,12 @@
 
 Here is the list of all the updates that I made on this template.
 
+### Vesion 5.2 (30 September 2022)
+
+* Added `load`, `reload` and `unload` commands.
+* Added `sync` and `unsync` commands.
+* Code refactoring and cleanup.
+
 ### Version 5.1 (12 September 2022)
 
 * Added the `help` command once again

--- a/bot.py
+++ b/bot.py
@@ -13,14 +13,12 @@ import platform
 import random
 import sqlite3
 import sys
-
 from contextlib import closing
 
 import discord
 from discord import Interaction
-from discord.ext import tasks, commands
-from discord.ext.commands import Bot
-from discord.ext.commands import Context
+from discord.ext import commands, tasks
+from discord.ext.commands import Bot, Context
 
 import exceptions
 
@@ -71,9 +69,10 @@ It is recommended to use slash commands and therefore not use prefix commands.
 
 If you want to use prefix commands, make sure to also enable the intent below in the Discord developer portal.
 """
-intents.message_content = True
+# intents.message_content = True
 
-bot = Bot(command_prefix=commands.when_mentioned_or(config["prefix"]), intents=intents, help_command=None)
+bot = Bot(command_prefix=commands.when_mentioned_or(
+    config["prefix"]), intents=intents, help_command=None)
 
 
 def init_db():
@@ -97,6 +96,7 @@ The config is available using the following code:
 bot.config = config
 bot.db = connect_db()
 
+
 @bot.event
 async def on_ready() -> None:
     """
@@ -108,7 +108,6 @@ async def on_ready() -> None:
     print(f"Running on: {platform.system()} {platform.release()} ({os.name})")
     print("-------------------")
     status_task.start()
-    await bot.tree.sync(guild=bot.get_guild(bot.config["dev_guild_id"])) # This will load only the 'sync' and 'unsync' commands for the dev guild
 
 
 @tasks.loop(minutes=1.0)
@@ -145,7 +144,8 @@ async def on_command_completion(context: Context) -> None:
         print(
             f"Executed {executed_command} command in {context.guild.name} (ID: {context.guild.id}) by {context.author} (ID: {context.author.id})")
     else:
-        print(f"Executed {executed_command} command by {context.author} (ID: {context.author.id}) in DMs")
+        print(
+            f"Executed {executed_command} command by {context.author} (ID: {context.author.id}) in DMs")
 
 
 @bot.event

--- a/bot.py
+++ b/bot.py
@@ -3,7 +3,7 @@ Copyright © Krypton 2022 - https://github.com/kkrypt0nn (https://krypton.ninja)
 Description:
 This is a template to create your own discord bot in python.
 
-Version: 5.1
+Version: 5.2
 """
 
 import asyncio

--- a/bot.py
+++ b/bot.py
@@ -71,7 +71,7 @@ It is recommended to use slash commands and therefore not use prefix commands.
 
 If you want to use prefix commands, make sure to also enable the intent below in the Discord developer portal.
 """
-# intents.message_content = True
+intents.message_content = True
 
 bot = Bot(command_prefix=commands.when_mentioned_or(config["prefix"]), intents=intents, help_command=None)
 
@@ -108,7 +108,7 @@ async def on_ready() -> None:
     print(f"Running on: {platform.system()} {platform.release()} ({os.name})")
     print("-------------------")
     status_task.start()
-    await bot.tree.sync()
+    await bot.tree.sync(guild=bot.get_guild(bot.config["dev_guild_id"])) # This will load only the 'sync' and 'unsync' commands for the dev guild
 
 
 @tasks.loop(minutes=1.0)

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -143,7 +143,6 @@ class Fun(commands.Cog, name="fun"):
         message = await context.send(embed=embed, view=buttons)
         await buttons.wait()  # We wait for the user to click a button.
         result = random.choice(["heads", "tails"])
-        print(buttons.value)
         if buttons.value == result:
             embed = discord.Embed(
                 description=f"Correct! You guessed `{buttons.value}` and I flipped the coin to `{result}`.",

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -3,7 +3,7 @@ Copyright © Krypton 2022 - https://github.com/kkrypt0nn (https://krypton.ninja)
 Description:
 This is a template to create your own discord bot in python.
 
-Version: 5.1
+Version: 5.2
 """
 
 import random

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -66,7 +66,9 @@ class RockPaperScissors(discord.ui.Select):
 
         result_embed = discord.Embed(color=0x9C84EF)
         result_embed.set_author(
-            name=interaction.user.name, icon_url=interaction.user.avatar.url)
+            name=interaction.user.name,
+            icon_url=interaction.user.avatar.url
+        )
 
         if user_choice_index == bot_choice_index:
             result_embed.description = f"**That's a draw!**\nYou've chosen {user_choice} and I've chosen {bot_choice}."

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -13,7 +13,6 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 from discord.ext.commands import Context
-
 from helpers import checks
 
 
@@ -66,7 +65,8 @@ class RockPaperScissors(discord.ui.Select):
         bot_choice_index = choices[bot_choice]
 
         result_embed = discord.Embed(color=0x9C84EF)
-        result_embed.set_author(name=interaction.user.name, icon_url=interaction.user.avatar.url)
+        result_embed.set_author(
+            name=interaction.user.name, icon_url=interaction.user.avatar.url)
 
         if user_choice_index == bot_choice_index:
             result_embed.description = f"**That's a draw!**\nYou've chosen {user_choice} and I've chosen {bot_choice}."
@@ -104,7 +104,7 @@ class Fun(commands.Cog, name="fun"):
     async def randomfact(self, context: Context) -> None:
         """
         Get a random fact.
-        
+
         :param context: The hybrid command context.
         """
         # This will prevent your bot from stopping everything when doing a web request - see: https://discordpy.readthedocs.io/en/stable/faq.html#how-do-i-make-a-web-request
@@ -132,7 +132,7 @@ class Fun(commands.Cog, name="fun"):
     async def coinflip(self, context: Context) -> None:
         """
         Make a coin flip, but give your bet before.
-        
+
         :param context: The hybrid command context.
         """
         buttons = Choice()
@@ -164,7 +164,7 @@ class Fun(commands.Cog, name="fun"):
     async def rock_paper_scissors(self, context: Context) -> None:
         """
         Play the rock paper scissors game against the bot.
-        
+
         :param context: The hybrid command context.
         """
         view = RockPaperScissorsView()

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -3,7 +3,7 @@ Copyright © Krypton 2022 - https://github.com/kkrypt0nn (https://krypton.ninja)
 Description:
 This is a template to create your own discord bot in python.
 
-Version: 5.1
+Version: 5.2
 """
 
 import platform

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -10,9 +10,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 from discord.ext.commands import Context
-
-from helpers import checks
-from helpers import db_manager
+from helpers import checks, db_manager
 
 
 class Moderation(commands.Cog, name="moderation"):
@@ -112,7 +110,7 @@ class Moderation(commands.Cog, name="moderation"):
     async def ban(self, context: Context, user: discord.User, reason: str = "Not specified") -> None:
         """
         Bans a user from the server.
-        
+
         :param context: The hybrid command context.
         :param user: The user that should be banned from the server.
         :param reason: The reason for the ban. Default is "Not specified".
@@ -176,7 +174,8 @@ class Moderation(commands.Cog, name="moderation"):
         :param reason: The reason for the warn. Default is "Not specified".
         """
         member = context.guild.get_member(user.id) or await context.guild.fetch_member(user.id)
-        total = db_manager.add_warn(user.id, context.guild.id, context.author.id, reason)
+        total = db_manager.add_warn(
+            user.id, context.guild.id, context.author.id, reason)
         embed = discord.Embed(
             title="User Warned!",
             description=f"**{member}** was warned by **{context.author}**!\nTotal warns for this user: {total}",
@@ -227,13 +226,13 @@ class Moderation(commands.Cog, name="moderation"):
     async def warning_list(self, context: Context, user: discord.User):
         """
         Shows the warnings of a user in the server.
-        
+
         :param context: The hybrid command context.
         :param user: The user you want to get the warnings of.
         """
         warnings_list = db_manager.get_warnings(user.id, context.guild.id)
         embed = discord.Embed(
-            title = f"Warnings of {user}",
+            title=f"Warnings of {user}",
             color=0x9C84EF
         )
         description = ""

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -3,7 +3,7 @@ Copyright © Krypton 2022 - https://github.com/kkrypt0nn (https://krypton.ninja)
 Description:
 This is a template to create your own discord bot in python.
 
-Version: 5.1
+Version: 5.2
 """
 
 import discord

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -3,7 +3,7 @@ Copyright © Krypton 2022 - https://github.com/kkrypt0nn (https://krypton.ninja)
 Description:
 This is a template to create your own discord bot in python.
 
-Version: 5.1
+Version: 5.2
 """
 
 import json

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -7,75 +7,150 @@ Version: 5.1
 """
 
 import json
+import os
+import sys
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 from discord.ext.commands import Context
 
 from helpers import checks
 from helpers import db_manager
 
+if not os.path.isfile("config.json"):
+    sys.exit("'config.json' not found! Please add it and try again.")
+else:
+    with open("config.json") as file:
+        config = json.load(file)
 
 class Owner(commands.Cog, name="owner"):
     def __init__(self, bot):
         self.bot = bot
     
+    DEV_GUILD = discord.Object(id=config["dev_guild_id"])
+
+    @commands.hybrid_command(
+        name="sync",
+        description="Synchonizes the slash commands.",
+    )
+    @checks.is_owner()
+    @app_commands.guilds(DEV_GUILD)
+    async def sync(self, context: Context) -> None:
+        """
+        Synchonizes the slash commands.
+
+        :param context: The hybrid command context.
+        """
+        await self.bot.tree.sync()
+        embed = discord.Embed(
+            title="Slash Commands Sync",
+            description="Slash commands have been synchronized.",
+        )
+        await context.send(embed=embed)
+
+    @commands.hybrid_command(
+        name="unsync",
+        description="Unsynchonizes the slash commands.",
+    )
+    @checks.is_owner()
+    @app_commands.guilds(DEV_GUILD)
+    async def unsync(self, context: Context) -> None:
+        """
+        Unsynchonizes the slash commands.
+
+        :param context: The hybrid command context.
+        """
+        self.bot.tree.clear_commands(guild=None)
+        await self.bot.tree.sync()
+        embed = discord.Embed(
+            title="Slash Commands Unsync",
+            description="Slash commands have been unsynchronized.",
+        )
+        await context.send(embed=embed)
+
     @commands.hybrid_command(
         name="load",
         description="Load a cog",
     )
+    @app_commands.describe(cog="The name of the cog to load")
     @checks.is_owner()
     async def load(self, context: Context, cog: str) -> None:
         """
         The bot will load the given cog.
+
         :param context: The hybrid command context.
-        :param cog: The cog to be loaded.
+        :param cog: The name of the cog to load.
         """
         try:
             await self.bot.load_extension(f"cogs.{cog}")
         except Exception as e:
-            embed=discord.Embed(title="Error!", description=f"Could not load the `{cog}` cog.")
-            await context.send(embed=embed); return
-        embed=discord.Embed(title="Load", description=f"Successfully loaded the `{cog}` cog.")
+            embed = discord.Embed(
+                title="Error!",
+                description=f"Could not load the `{cog}` cog."
+            )
+            await context.send(embed=embed)
+            return
+        embed = discord.Embed(
+            title="Load",
+            description=f"Successfully loaded the `{cog}` cog."
+        )
         await context.send(embed=embed)
-
 
     @commands.hybrid_command(
         name="unload",
         description="Unloads a cog.",
     )
+    @app_commands.describe(cog="The name of the cog to unload")
     @checks.is_owner()
     async def unload(self, context: Context, cog: str) -> None:
         """
         The bot will unload the given cog.
+
         :param context: The hybrid command context.
-        :param cog: The cog to be unloaded.
+        :param cog: The name of the cog to unload.
         """
         try:
             await self.bot.unload_extension(f"cogs.{cog}")
         except Exception as e:
-            embed=discord.Embed(title="Error!", description=f"Could not unload the `{cog}` cog.")
-            await context.send(embed=embed); return
-        embed=discord.Embed(title="Unload", description=f"Successfully loaded the `{cog}` cog.")
+            embed = discord.Embed(
+                title="Error!",
+                description=f"Could not unload the `{cog}` cog."
+            )
+            await context.send(embed=embed)
+            return
+        embed = discord.Embed(
+            title="Unload",
+            description=f"Successfully loaded the `{cog}` cog."
+        )
         await context.send(embed=embed)
 
     @commands.hybrid_command(
         name="reload",
         description="Reloads a cog.",
     )
+    @app_commands.describe(cog="The name of the cog to reload")
     @checks.is_owner()
     async def reload(self, context: Context, cog: str) -> None:
         """
         The bot will reload the given cog.
+
         :param context: The hybrid command context.
-        :param cog: The cog to be reloaded.
+        :param cog: The name of the cog to reload.
         """
         try:
             await self.bot.reload_extension(f"cogs.{cog}")
         except Exception as e:
-            embed=discord.Embed(title="Error!", description=f"Could not reload the `{cog}` cog.")
-            await context.send(embed=embed); return
-        embed=discord.Embed(title="Reload", description=f"Successfully reloaded the `{cog}` cog.")
+            embed = discord.Embed(
+                title="Error!",
+                description=f"Could not reload the `{cog}` cog."
+            )
+            await context.send(embed=embed)
+            return
+        embed = discord.Embed(
+            title="Reload",
+            description=f"Successfully reloaded the `{cog}` cog."
+        )
         await context.send(embed=embed)    
 
     @commands.hybrid_command(
@@ -100,6 +175,7 @@ class Owner(commands.Cog, name="owner"):
         name="say",
         description="The bot will say anything you want.",
     )
+    @app_commands.describe(message="The message that should be repeated by the bot")
     @checks.is_owner()
     async def say(self, context: Context, message: str) -> None:
         """
@@ -114,6 +190,7 @@ class Owner(commands.Cog, name="owner"):
         name="embed",
         description="The bot will say anything you want, but within embeds.",
     )
+    @app_commands.describe(message="The message that should be repeated by the bot")
     @checks.is_owner()
     async def embed(self, context: Context, message: str) -> None:
         """
@@ -146,6 +223,7 @@ class Owner(commands.Cog, name="owner"):
         name="add",
         description="Lets you add a user from not being able to use the bot.",
     )
+    @app_commands.describe(user="The user that should be added to the blacklist")
     @checks.is_owner()
     async def blacklist_add(self, context: Context, user: discord.User) -> None:
         """
@@ -161,7 +239,8 @@ class Owner(commands.Cog, name="owner"):
                 description=f"**{user.name}** is not in the blacklist.",
                 color=0xE02B2B
             )
-            return await context.send(embed=embed)
+            await context.send(embed=embed)
+            return
         total = db_manager.add_user_to_blacklist(user_id)
         embed = discord.Embed(
             title="User Blacklisted",
@@ -178,8 +257,9 @@ class Owner(commands.Cog, name="owner"):
         name="remove",
         description="Lets you remove a user from not being able to use the bot.",
     )
+    @app_commands.describe(user="The user that should be removed from the blacklist.")
     @checks.is_owner()
-    async def blacklist_remove(self, context: Context, user: discord.User):
+    async def blacklist_remove(self, context: Context, user: discord.User) -> None:
         """
         Lets you remove a user from not being able to use the bot.
 
@@ -193,7 +273,8 @@ class Owner(commands.Cog, name="owner"):
                 description=f"**{user.name}** is already in the blacklist.",
                 color=0xE02B2B
             )
-            return await context.send(embed=embed)
+            await context.send(embed=embed)
+            return
         total = db_manager.remove_user_from_blacklist(user_id)
         embed = discord.Embed(
             title="User removed from blacklist",

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -25,7 +25,7 @@ class Owner(commands.Cog, name="owner"):
         description="Load a cog",
     )
     @checks.is_owner()
-    async def load(self, ctx, cog: str):
+    async def load(self, context: Context, cog: str):
          """
         The bot will load the given cog.
 
@@ -35,11 +35,10 @@ class Owner(commands.Cog, name="owner"):
         try:
             await self.bot.load_extension(f"cogs.{cog}")
         except Exception as e:
-            embed=discord.Embed(title="load", description=f"Could not load the `{cog}` cog.")
-            await ctx.send(embed=embed)
-            return
+            embed=discord.Embed(title="Error!", description=f"Could not load the `{cog}` cog.")
+            await context.send(embed=embed) return
         embed=discord.Embed(title="Load", description=f"Successfully loaded the `{cog}` cog.")
-        await ctx.send(embed=embed)
+        await context.send(embed=embed)
 
 
     @commands.hybrid_command(
@@ -47,7 +46,7 @@ class Owner(commands.Cog, name="owner"):
         description="Unloads a cog.",
     )
     @checks.is_owner()
-    async def unload(self, ctx, cog: str):
+    async def unload(self, context: Context, cog: str):
         """
         The bot will unload the given cog.
 
@@ -57,18 +56,17 @@ class Owner(commands.Cog, name="owner"):
         try:
             await self.bot.unload_extension(f"cogs.{cog}")
         except Exception as e:
-            embed=discord.Embed(title="Unload", description=f"Could not unload the `{cog}` cog.")
-            await ctx.send(embed=embed)
-            return
+            embed=discord.Embed(title="Error!", description=f"Could not unload the `{cog}` cog.")
+            await context.send(embed=embed) return
         embed=discord.Embed(title="Unload", description=f"Successfully loaded the `{cog}` cog.")
-        await ctx.send(embed=embed)
+        await context.send(embed=embed)
 
     @commands.hybrid_command(
         name="reload",
         description="Reloads a cog.",
     )
     @checks.is_owner()
-    async def reload(self, ctx, cog: str):
+    async def reload(self, context: Context, cog: str):
         """
         The bot will reload the given cog.
 
@@ -76,14 +74,12 @@ class Owner(commands.Cog, name="owner"):
         :param cog: The cog to be reloaded.
         """
         try:
-            await self.bot.unload_extension(f"cogs.{cog}")
-            await self.bot.load_extension(f"cogs.{cog}")
+            await self.bot.reload_extension(f"cogs.{cog}")
         except Exception as e:
-            embed=discord.Embed(title="Reload", description=f"Could not reload the `{cog}` cog.")
-            await ctx.send(embed=embed)
-            return
+            embed=discord.Embed(title="Error!", description=f"Could not reload the `{cog}` cog.")
+            await context.send(embed=embed) return
         embed=discord.Embed(title="Reload", description=f"Successfully reloaded the `{cog}` cog.")
-        await ctx.send(embed=embed)    
+        await context.send(embed=embed)    
 
     @commands.hybrid_command(
         name="shutdown",

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -19,6 +19,71 @@ from helpers import db_manager
 class Owner(commands.Cog, name="owner"):
     def __init__(self, bot):
         self.bot = bot
+    
+    @commands.hybrid_command(
+        name="load",
+        description="Load a cog",
+    )
+    @checks.is_owner()
+    async def load(self, ctx, cog: str):
+         """
+        The bot will load the given cog.
+
+        :param context: The hybrid command context.
+        :param cog: The cog to be loaded.
+        """
+        try:
+            await self.bot.load_extension(f"cogs.{cog}")
+        except Exception as e:
+            embed=discord.Embed(title="load", description=f"Could not load the `{cog}` cog.")
+            await ctx.send(embed=embed)
+            return
+        embed=discord.Embed(title="Load", description=f"Successfully loaded the `{cog}` cog.")
+        await ctx.send(embed=embed)
+
+
+    @commands.hybrid_command(
+        name="unload",
+        description="Unloads a cog.",
+    )
+    @checks.is_owner()
+    async def unload(self, ctx, cog: str):
+        """
+        The bot will unload the given cog.
+
+        :param context: The hybrid command context.
+        :param cog: The cog to be unloaded.
+        """
+        try:
+            await self.bot.unload_extension(f"cogs.{cog}")
+        except Exception as e:
+            embed=discord.Embed(title="Unload", description=f"Could not unload the `{cog}` cog.")
+            await ctx.send(embed=embed)
+            return
+        embed=discord.Embed(title="Unload", description=f"Successfully loaded the `{cog}` cog.")
+        await ctx.send(embed=embed)
+
+    @commands.hybrid_command(
+        name="reload",
+        description="Reloads a cog.",
+    )
+    @checks.is_owner()
+    async def reload(self, ctx, cog: str):
+        """
+        The bot will reload the given cog.
+
+        :param context: The hybrid command context.
+        :param cog: The cog to be reloaded.
+        """
+        try:
+            await self.bot.unload_extension(f"cogs.{cog}")
+            await self.bot.load_extension(f"cogs.{cog}")
+        except Exception as e:
+            embed=discord.Embed(title="Reload", description=f"Could not reload the `{cog}` cog.")
+            await ctx.send(embed=embed)
+            return
+        embed=discord.Embed(title="Reload", description=f"Successfully reloaded the `{cog}` cog.")
+        await ctx.send(embed=embed)    
 
     @commands.hybrid_command(
         name="shutdown",

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -16,12 +16,6 @@ from discord.ext import commands
 from discord.ext.commands import Context
 from helpers import checks, db_manager
 
-if not os.path.isfile("config.json"):
-    sys.exit("'config.json' not found! Please add it and try again.")
-else:
-    with open("config.json") as file:
-        config = json.load(file)
-
 
 class Owner(commands.Cog, name="owner"):
     def __init__(self, bot):

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -49,6 +49,7 @@ class Owner(commands.Cog, name="owner"):
                 color=0x9C84EF
             )
             await context.send(embed=embed)
+            return
         elif scope == "guild":
             context.bot.tree.copy_global_to(guild=context.guild)
             await context.bot.tree.sync(guild=context.guild)
@@ -58,13 +59,13 @@ class Owner(commands.Cog, name="owner"):
                 color=0x9C84EF
             )
             await context.send(embed=embed)
-        else:
-            embed = discord.Embed(
-                title="Invalid Scope",
-                description="The scope must be `global` or `guild`.",
-                color=0xE02B2B
-            )
-            await context.send(embed=embed)
+            return
+        embed = discord.Embed(
+            title="Invalid Scope",
+            description="The scope must be `global` or `guild`.",
+            color=0xE02B2B
+        )
+        await context.send(embed=embed)
 
     @commands.command(
         name="unsync",
@@ -89,6 +90,7 @@ class Owner(commands.Cog, name="owner"):
                 color=0x9C84EF
             )
             await context.send(embed=embed)
+            return
         elif scope == "guild":
             context.bot.tree.clear_commands(guild=context.guild)
             await context.bot.tree.sync(guild=context.guild)
@@ -98,13 +100,13 @@ class Owner(commands.Cog, name="owner"):
                 color=0x9C84EF
             )
             await context.send(embed=embed)
-        else:
-            embed = discord.Embed(
-                title="Invalid Scope",
-                description="The scope must be `global` or `guild`.",
-                color=0xE02B2B
-            )
-            await context.send(embed=embed)
+            return
+        embed = discord.Embed(
+            title="Invalid Scope",
+            description="The scope must be `global` or `guild`.",
+            color=0xE02B2B
+        )
+        await context.send(embed=embed)
 
     @commands.hybrid_command(
         name="load",
@@ -121,16 +123,18 @@ class Owner(commands.Cog, name="owner"):
         """
         try:
             await self.bot.load_extension(f"cogs.{cog}")
-        except Exception as e:
+        except Exception:
             embed = discord.Embed(
                 title="Error!",
-                description=f"Could not load the `{cog}` cog."
+                description=f"Could not load the `{cog}` cog.",
+                color=0xE02B2B
             )
             await context.send(embed=embed)
             return
         embed = discord.Embed(
             title="Load",
-            description=f"Successfully loaded the `{cog}` cog."
+            description=f"Successfully loaded the `{cog}` cog.",
+            color=0x9C84EF
         )
         await context.send(embed=embed)
 
@@ -149,16 +153,18 @@ class Owner(commands.Cog, name="owner"):
         """
         try:
             await self.bot.unload_extension(f"cogs.{cog}")
-        except Exception as e:
+        except Exception:
             embed = discord.Embed(
                 title="Error!",
-                description=f"Could not unload the `{cog}` cog."
+                description=f"Could not unload the `{cog}` cog.",
+                color=0xE02B2B
             )
             await context.send(embed=embed)
             return
         embed = discord.Embed(
             title="Unload",
-            description=f"Successfully loaded the `{cog}` cog."
+            description=f"Successfully unloaded the `{cog}` cog.",
+            color=0x9C84EF
         )
         await context.send(embed=embed)
 
@@ -177,16 +183,18 @@ class Owner(commands.Cog, name="owner"):
         """
         try:
             await self.bot.reload_extension(f"cogs.{cog}")
-        except Exception as e:
+        except Exception:
             embed = discord.Embed(
                 title="Error!",
-                description=f"Could not reload the `{cog}` cog."
+                description=f"Could not reload the `{cog}` cog.",
+                color=0xE02B2B
             )
             await context.send(embed=embed)
             return
         embed = discord.Embed(
             title="Reload",
-            description=f"Successfully reloaded the `{cog}` cog."
+            description=f"Successfully reloaded the `{cog}` cog.",
+            color=0x9C84EF
         )
         await context.send(embed=embed)
 

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -36,7 +36,7 @@ class Owner(commands.Cog, name="owner"):
             await self.bot.load_extension(f"cogs.{cog}")
         except Exception as e:
             embed=discord.Embed(title="Error!", description=f"Could not load the `{cog}` cog.")
-            await context.send(embed=embed) return
+            await context.send(embed=embed)
         embed=discord.Embed(title="Load", description=f"Successfully loaded the `{cog}` cog.")
         await context.send(embed=embed)
 
@@ -57,7 +57,7 @@ class Owner(commands.Cog, name="owner"):
             await self.bot.unload_extension(f"cogs.{cog}")
         except Exception as e:
             embed=discord.Embed(title="Error!", description=f"Could not unload the `{cog}` cog.")
-            await context.send(embed=embed) return
+            await context.send(embed=embed)
         embed=discord.Embed(title="Unload", description=f"Successfully loaded the `{cog}` cog.")
         await context.send(embed=embed)
 
@@ -77,7 +77,7 @@ class Owner(commands.Cog, name="owner"):
             await self.bot.reload_extension(f"cogs.{cog}")
         except Exception as e:
             embed=discord.Embed(title="Error!", description=f"Could not reload the `{cog}` cog.")
-            await context.send(embed=embed) return
+            await context.send(embed=embed)
         embed=discord.Embed(title="Reload", description=f"Successfully reloaded the `{cog}` cog.")
         await context.send(embed=embed)    
 

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -25,10 +25,9 @@ class Owner(commands.Cog, name="owner"):
         description="Load a cog",
     )
     @checks.is_owner()
-    async def load(self, context: Context, cog: str):
+    async def load(self, context: Context, cog: str) -> None:
         """
         The bot will load the given cog.
-
         :param context: The hybrid command context.
         :param cog: The cog to be loaded.
         """
@@ -36,7 +35,7 @@ class Owner(commands.Cog, name="owner"):
             await self.bot.load_extension(f"cogs.{cog}")
         except Exception as e:
             embed=discord.Embed(title="Error!", description=f"Could not load the `{cog}` cog.")
-            await context.send(embed=embed)
+            await context.send(embed=embed); return
         embed=discord.Embed(title="Load", description=f"Successfully loaded the `{cog}` cog.")
         await context.send(embed=embed)
 
@@ -46,10 +45,9 @@ class Owner(commands.Cog, name="owner"):
         description="Unloads a cog.",
     )
     @checks.is_owner()
-    async def unload(self, context: Context, cog: str):
+    async def unload(self, context: Context, cog: str) -> None:
         """
         The bot will unload the given cog.
-
         :param context: The hybrid command context.
         :param cog: The cog to be unloaded.
         """
@@ -57,7 +55,7 @@ class Owner(commands.Cog, name="owner"):
             await self.bot.unload_extension(f"cogs.{cog}")
         except Exception as e:
             embed=discord.Embed(title="Error!", description=f"Could not unload the `{cog}` cog.")
-            await context.send(embed=embed)
+            await context.send(embed=embed); return
         embed=discord.Embed(title="Unload", description=f"Successfully loaded the `{cog}` cog.")
         await context.send(embed=embed)
 
@@ -66,10 +64,9 @@ class Owner(commands.Cog, name="owner"):
         description="Reloads a cog.",
     )
     @checks.is_owner()
-    async def reload(self, context: Context, cog: str):
+    async def reload(self, context: Context, cog: str) -> None:
         """
         The bot will reload the given cog.
-
         :param context: The hybrid command context.
         :param cog: The cog to be reloaded.
         """
@@ -77,7 +74,7 @@ class Owner(commands.Cog, name="owner"):
             await self.bot.reload_extension(f"cogs.{cog}")
         except Exception as e:
             embed=discord.Embed(title="Error!", description=f"Could not reload the `{cog}` cog.")
-            await context.send(embed=embed)
+            await context.send(embed=embed); return
         embed=discord.Embed(title="Reload", description=f"Successfully reloaded the `{cog}` cog.")
         await context.send(embed=embed)    
 

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -26,7 +26,7 @@ class Owner(commands.Cog, name="owner"):
     )
     @checks.is_owner()
     async def load(self, context: Context, cog: str):
-         """
+        """
         The bot will load the given cog.
 
         :param context: The hybrid command context.

--- a/cogs/template.py
+++ b/cogs/template.py
@@ -3,7 +3,7 @@ Copyright © Krypton 2022 - https://github.com/kkrypt0nn (https://krypton.ninja)
 Description:
 This is a template to create your own discord bot in python.
 
-Version: 5.1
+Version: 5.2
 """
 
 from discord.ext import commands

--- a/cogs/template.py
+++ b/cogs/template.py
@@ -8,7 +8,6 @@ Version: 5.1
 
 from discord.ext import commands
 from discord.ext.commands import Context
-
 from helpers import checks
 
 
@@ -17,8 +16,8 @@ class Template(commands.Cog, name="template"):
     def __init__(self, bot):
         self.bot = bot
 
-
     # Here you can just add your own commands, you'll always need to provide "self" as first parameter.
+
     @commands.hybrid_command(
         name="testcommand",
         description="This is a testing command that does nothing.",

--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
   "token": "YOUR_BOT_TOKEN_HERE",
   "permissions": "YOUR_BOT_PERMISSIONS_HERE",
   "application_id": "YOUR_APPLICATION_ID_HERE",
+  "dev_guild_id": "YOUR_DEVELOPMENT_GUILD_ID_HERE",
   "owners": [
     123456789,
     987654321

--- a/config.json
+++ b/config.json
@@ -3,7 +3,6 @@
   "token": "YOUR_BOT_TOKEN_HERE",
   "permissions": "YOUR_BOT_PERMISSIONS_HERE",
   "application_id": "YOUR_APPLICATION_ID_HERE",
-  "dev_guild_id": "YOUR_DEVELOPMENT_GUILD_ID_HERE",
   "owners": [
     123456789,
     987654321

--- a/exceptions/__init__.py
+++ b/exceptions/__init__.py
@@ -3,7 +3,7 @@ Copyright © Krypton 2022 - https://github.com/kkrypt0nn (https://krypton.ninja)
 Description:
 This is a template to create your own discord bot in python.
 
-Version: 5.1
+Version: 5.2
 """
 
 from discord.ext import commands

--- a/helpers/checks.py
+++ b/helpers/checks.py
@@ -3,7 +3,7 @@ Copyright © Krypton 2022 - https://github.com/kkrypt0nn (https://krypton.ninja)
 Description:
 This is a template to create your own discord bot in python.
 
-Version: 5.1
+Version: 5.2
 """
 
 import json

--- a/helpers/checks.py
+++ b/helpers/checks.py
@@ -7,10 +7,9 @@ Version: 5.1
 """
 
 import json
-from typing import TypeVar, Callable
+from typing import Callable, TypeVar
 
 from discord.ext import commands
-
 from exceptions import *
 
 from helpers import db_manager

--- a/helpers/db_manager.py
+++ b/helpers/db_manager.py
@@ -8,10 +8,11 @@ Version: 5.1
 
 import sqlite3
 
+
 def is_blacklisted(user_id: int) -> bool:
     """
     This function will check if a user is blacklisted.
-    
+
     :param user_id: The ID of the user that should be checked.
     :return: True if the user is blacklisted, False if not.
     """
@@ -26,7 +27,7 @@ def is_blacklisted(user_id: int) -> bool:
 def add_user_to_blacklist(user_id: int) -> int:
     """
     This function will add a user based on its ID in the blacklist.
-    
+
     :param user_id: The ID of the user that should be added into the blacklist.
     """
     connection = sqlite3.connect("database/database.db")
@@ -41,7 +42,7 @@ def add_user_to_blacklist(user_id: int) -> int:
 def remove_user_from_blacklist(user_id: int) -> int:
     """
     This function will remove a user based on its ID from the blacklist.
-    
+
     :param user_id: The ID of the user that should be removed from the blacklist.
     """
     connection = sqlite3.connect("database/database.db")
@@ -56,18 +57,21 @@ def remove_user_from_blacklist(user_id: int) -> int:
 def add_warn(user_id: int, server_id: int, moderator_id: int, reason: str) -> int:
     """
     This function will add a warn to the database.
-    
+
     :param user_id: The ID of the user that should be warned.
     :param reason: The reason why the user should be warned.
     """
     connection = sqlite3.connect("database/database.db")
     cursor = connection.cursor()
     # Get the last `id`
-    rows = cursor.execute("SELECT id FROM warns WHERE user_id=? AND server_id=? ORDER BY id DESC LIMIT 1", (user_id, server_id,)).fetchone()
+    rows = cursor.execute(
+        "SELECT id FROM warns WHERE user_id=? AND server_id=? ORDER BY id DESC LIMIT 1", (user_id, server_id,)).fetchone()
     warn_id = rows[0]+1 if rows is not None else 1
-    cursor.execute("INSERT INTO warns(id, user_id, server_id, moderator_id, reason) VALUES (?, ?, ?, ?, ?)", (warn_id, user_id, server_id, moderator_id, reason,))
+    cursor.execute("INSERT INTO warns(id, user_id, server_id, moderator_id, reason) VALUES (?, ?, ?, ?, ?)",
+                   (warn_id, user_id, server_id, moderator_id, reason,))
     connection.commit()
-    rows = cursor.execute("SELECT COUNT(*) FROM warns WHERE user_id=? AND server_id=?", (user_id, server_id,)).fetchone()[0]
+    rows = cursor.execute(
+        "SELECT COUNT(*) FROM warns WHERE user_id=? AND server_id=?", (user_id, server_id,)).fetchone()[0]
     connection.close()
     return rows
 
@@ -75,23 +79,26 @@ def add_warn(user_id: int, server_id: int, moderator_id: int, reason: str) -> in
 def remove_warn(warn_id: int, user_id: int, server_id: int) -> int:
     """
     This function will remove a warn from the database.
-    
+
     :param warn_id: The ID of the warn.
     :param user_id: The ID of the user that was warned.
     :param server_id: The ID of the server where the user has been warned
     """
     connection = sqlite3.connect("database/database.db")
     cursor = connection.cursor()
-    cursor.execute("DELETE FROM warns WHERE id=? AND user_id=? AND server_id=?", (warn_id, user_id, server_id,))
+    cursor.execute("DELETE FROM warns WHERE id=? AND user_id=? AND server_id=?",
+                   (warn_id, user_id, server_id,))
     connection.commit()
-    rows = cursor.execute("SELECT COUNT(*) FROM warns WHERE user_id=? AND server_id=?", (user_id, server_id,)).fetchone()[0]
+    rows = cursor.execute(
+        "SELECT COUNT(*) FROM warns WHERE user_id=? AND server_id=?", (user_id, server_id,)).fetchone()[0]
     connection.close()
     return rows
+
 
 def get_warnings(user_id: int, server_id: int) -> list:
     """
     This function will get all the warnings of a user.
-    
+
     :param user_id: The ID of the user that should be checked.
     :param server_id: The ID of the server that should be checked.
     :return: A list of all the warnings of the user.

--- a/helpers/db_manager.py
+++ b/helpers/db_manager.py
@@ -3,7 +3,7 @@ Copyright © Krypton 2022 - https://github.com/kkrypt0nn (https://krypton.ninja)
 Description:
 This is a template to create your own discord bot in python.
 
-Version: 5.1
+Version: 5.2
 """
 
 import sqlite3


### PR DESCRIPTION
I've added the load, unload, and reload cog commands to the `owner` cog. This will allow the bot's owner to use cogs more efficiently without restarting the bot with every change.