### PR TITLE
Fix exception when checking owner status and guild is not present

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -235,8 +235,12 @@ async def on_command_error(context: Context, error) -> None:
             color=0xE02B2B
         )
         await context.send(embed=embed)
-        bot.logger.warning(
-            f"{context.author} (ID: {context.author.id}) tried to execute an owner only command in the guild {context.guild.name} (ID: {context.guild.id}), but the user is not an owner of the bot.")
+        if context.guild:
+            bot.logger.warning(
+                f"{context.author} (ID: {context.author.id}) tried to execute an owner only command in the guild {context.guild.name} (ID: {context.guild.id}), but the user is not an owner of the bot.")
+        else:
+            bot.logger.warning(
+                f"{context.author} (ID: {context.author.id}) tried to execute an owner only command in a direct message, but the user is not an owner of the bot.")
     elif isinstance(error, commands.MissingPermissions):
         embed = discord.Embed(
             description="You are missing the permission(s) `" + ", ".join(


### PR DESCRIPTION
Just found this repo recently, love it!

I've been testing my bot and ran into an issue where owner only commands were failing in DMs.  I used the testcommand and get this traceback due to `context.guild` not containing expected attributes.  PR is a simple fix for this issue.

```Traceback (most recent call last):
  File "/home/apd/projects/mrvn-apexlegends-discord-bot/venv/lib/python3.10/site-packages/discord/client.py", line 409, in _run_event
    await coro(*args, **kwargs)
  File "/home/apd/projects/mrvn-apexlegends-discord-bot/bot.py", line 239, in on_command_error
    f"{context.author} (ID: {context.author.id}) tried to execute an owner only command in the guild {context.guild.name} (ID: {context.guild.id}), but the user is not an owner of the bot.")
AttributeError: 'NoneType' object has no attribute 'name'