### PR TITLE
fix: Specified utf-8 encoding when opening schema.sql

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -143,7 +143,8 @@ class DiscordBot(commands.Bot):
             f"{os.path.realpath(os.path.dirname(__file__))}/database/database.db"
         ) as db:
             with open(
-                f"{os.path.realpath(os.path.dirname(__file__))}/database/schema.sql"
+                f"{os.path.realpath(os.path.dirname(__file__))}/database/schema.sql",
+                encoding = "utf-8"
             ) as file:
                 await db.executescript(file.read())
             await db.commit()


### PR DESCRIPTION
In init_db, schema.sql is opened without specifying utf-8 encoding. For me (German), this resulted in issues with text encoding in my database. This fixed it for me